### PR TITLE
Update README.md to clarify component naming and fix spelling/grammar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ES6 modules are supported via SystemJS module loader library.
 To start, create `app.ts` file, import `Component` and `View` and then bootstrap the app:
 ````ts
     import {Component, View, bootstrap} from 'angular2/angular2';
-    
+
     @Component({
       selector: 'socially'
     })
@@ -26,7 +26,7 @@ To start, create `app.ts` file, import `Component` and `View` and then bootstrap
       template: "<p>Hello World!</p>"
     })
     class Socially {}
-    
+
     bootstrap(Socially);
 ````
 
@@ -38,7 +38,7 @@ Add `index.html` file to the app top folder:
 ````
 At this point you should see app working and showing "Hello word".
 
-If you have HTML file in the app root folder with `body` or `head` tag (`index.html` in our case), the package will recognize it as your master HTML file and will skip inserting a default layout. Otherwise, it'll insert bootstrap HTML as follows:
+If you have an HTML file in the app root folder with `body` or `head` tag (`index.html` in our case), the package will recognize it as your master HTML file and will skip inserting a default layout. Otherwise, it'll insert bootstrap HTML as follows:
 ````html
 <body>
     <app></app>
@@ -46,7 +46,7 @@ If you have HTML file in the app root folder with `body` or `head` tag (`index.h
 ````
 Also, if you name your main client component `app.ts`, the package will import `client/app` System.js module for you.
 
-You can name it as you want, only this time you'll need to import it manually by adding next script to the `index.html` or some JS file (say, `main.js`):
+You can name the component whatever you want, but when doing so you'll need to import it manually by adding the next script in the `index.html` or some JS file (say, `main.js`):
 ````js
 Meteor.startup(() => {
     System.import('client/foo');
@@ -61,9 +61,9 @@ To do that, import `bootstrap` from Meteor-Angular2 package and remove previous 
 
 ````ts
     import {bootstrap} from 'angular2-meteor';
-    
+
     ....
-    
+
     bootstrap(Socially);
 ````
 
@@ -72,7 +72,7 @@ After that, you can use Meteor collections in the same way as you would do in a 
 For example, change `client/app.ts` to:
 ````ts
     ....
-    
+
     @View({
       templateUrl: 'client/parties.html'
     })
@@ -81,7 +81,7 @@ For example, change `client/app.ts` to:
           this.parties = Parties.find();
         }
     }
-    
+
     ....
 ````
 
@@ -94,13 +94,13 @@ Add Angular2 template file `client/parties.html` with a content as follows:
 
 At this moment, you are ready to create awesome apps backed by the power of Angular2 and Meteor!
 
-There is some details left though.
+There are some details left though.
 For more information, please check Parties demo app.
 
 ### Server Side
-You can import TypeScript and System.js on the server side same way as on the client side.
+You can import TypeScript and System.js on the server side same way you can on the client side.
 
-Similar to the client's main module `app.ts`, the package checks existance of `main.ts` file in the server folder and, in case of success, will import it for you. Otherwise, you can name main module as you want and import by:
+Similar to the client's main module `app.ts`, the package checks for the existence of the `main.ts` file in the server folder and, in case of success, will import it for you. Otherwise, you can name main module as you want and import by:
 ````ts
 Meteor.startup(() => {
     System.import('server/foo').await();
@@ -115,12 +115,12 @@ So, if you have code like this:
 ````ts
     var parties = new Mongo.Collection('parties');
 ````
-It will likely curse that `Mongo` is undefined. Luckily, package adds Angular2 and Meteor declaration file, which means you'll need only to reference it in your TypeScript files to fix errors. 
+It will likely curse that `Mongo` is undefined. Luckily, package adds Angular2 and Meteor declaration file, which means you'll need only to reference it in your TypeScript files to fix errors.
 
-When you first run your app, Angular2-Meteor will create a declarations (or typings) file `typings/angular2-meteor.d.ts` in your app folder . Add reference to it in every TypeScript file you have created or are going to create as follows:
+When you first run your app, Angular2-Meteor will create a declarations (or typings) file `typings/angular2-meteor.d.ts` in your app folder . Add references to it in every TypeScript file you have created or are going to create as follows:
 ````ts
 /// <reference path="../typings/angular2-meteor.d.ts" />
 ````
 Make sure that paths are relative to the app top folder.
 
-> Note: if you just loaded your app from a repository into empty folder and is running it first time, you'll need to re-start it in order to have all package declaration files in place.
+> Note: if you just loaded your app from a repository into an empty folder and you're running it for the first time, you'll need to re-start it in order to have all package declaration files in place.


### PR DESCRIPTION
The main point of this update was to clarify the bit about naming the main component, but also to fix some spelling and grammar issues.