### PR TITLE
fix startup error on Windows caused by mkdirp

### DIFF
--- a/plugin/typings_init.js
+++ b/plugin/typings_init.js
@@ -6,7 +6,7 @@ var typingsDir = path.resolve('./typings');
 var typingsFile = path.resolve(typingsDir, 'angular2-meteor.d.ts');
 
 if(canProceed() && !fs.existsSync(typingsDir)) {
-  mkdirp.sync(typingsDir);
+  mkdirp.sync(Plugin.convertToOsPath(typingsDir));
 }
 
 if (canProceed() && !fs.existsSync(typingsFile)) {


### PR DESCRIPTION
mkdirp doesn't create directory correctly on Windows environment.

This can be fixed easily by calling Plugin.convertToOsPath(), see https://github.com/meteor/meteor/wiki/Build-Plugins-API#accessing-file-system for details.