### PR TITLE
update import statement to reflect changes to angular2 namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ ES6 modules are supported via SystemJS module loader library.
 
 To start, create `app.ts` file, import `Component` and `View` and then bootstrap the app:
 ````ts
-    import {Component, View, bootstrap} from 'angular2/angular2';
+    import {Component, View} from 'angular2/core';
+    import {bootstrap} from 'angular2-meteor';
 
     @Component({
       selector: 'socially'


### PR DESCRIPTION
This brings the quick-start section of README up to date with the new namespacing of alpha-50 +. 